### PR TITLE
Override choo _matchRoute instead of creating dummy router

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ function Detached (opts) {
 
     this.handler = null
 
-    this._matchRoute = this._matchRoute.bind(this, "/")
+    this._matchRoute = this._matchRoute.bind(this, '/')
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -14,15 +14,7 @@ function Detached (opts) {
 
     this.handler = null
 
-    var self = this
-    this.router = function () {
-      assert.notEqual(self.handler, null, 'choo: component has no existing component handler')
-
-      return self.handler(self.state, function (eventName, data) {
-        self.emitter.emit(eventName, data)
-      })
-    }
-    this.router.on = function () {}
+    this._matchRoute = this._matchRoute.bind(this, "/")
   }
 }
 
@@ -33,7 +25,7 @@ Detached.prototype.component = function (handler) {
   assert.notEqual(this._detached, false, 'choo: attempt to mount component in non-detached mode')
   assert.equal(typeof handler, 'function', 'choo: handler should be type function')
 
-  this.handler = handler
+  this.route('/', handler)
 }
 
 module.exports = Detached

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "author": "Maciej Sitko",
   "license": "ISC",
   "dependencies": {
-    "choo": "^6.1.0",
+    "choo": "^6.7.0",
     "assert": "^1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
With choo 6.6.0 there was a router error when using choo-devtools with choo-detached. With choo 6.7.0 even without choo-devtools there was a router error:

```
Uncaught TypeError: this.router.match is not a function
    at Detached.Choo._matchRoute (index.js:205)
    at Detached.Choo.start (index.js:127)
    at index.js:163
```

This change fixes both issues.